### PR TITLE
Markdown code class doesn’t follow convention

### DIFF
--- a/lib/template/processors/md.js
+++ b/lib/template/processors/md.js
@@ -1,4 +1,4 @@
-var marked = require("marked")
+var marked = require("marked").setOptions({ langPrefix: 'language-' })
 var TerraformError = require("../../error").TerraformError
 
 module.exports = function(fileContents, options){

--- a/test/fixtures/templates/stuff.md
+++ b/test/fixtures/templates/stuff.md
@@ -1,3 +1,12 @@
 # hello markdown
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+```json
+{
+  "hello-saturn": {
+    "title": "Hello, Saturn",
+    "date": "1610-01-01"
+  }
+}
+```

--- a/test/templates.js
+++ b/test/templates.js
@@ -24,6 +24,8 @@ describe("templates", function(){
         should.exist(body)
         body.should.include("<h1>hello markdown</h1>")
         body.should.include("<p>")
+        body.should.include('<code class="language-json">')
+        body.should.not.include('<code class="lang-json">')
         done()
       })
     })


### PR DESCRIPTION
The [W3C](http://www.w3.org/TR/html5/text-level-semantics.html#the-code-element) and [WHATWG](http://www.whatwg.org/specs/web-apps/current-work/multipage/text-level-semantics.html#the-code-element) suggest using `language-` as the prefix for the class name on code blocks. This hasn’t been changed in Marked yet, so writing:

<pre class="markdown">
```json
"hello-world": {
  "title": "the-title"
}
```
</pre>


generates HTML with the class `lang-json` instead of `language-json`.
