### PR TITLE
Adds failing test for escaping CSS error messages

### DIFF
--- a/test/errors.js
+++ b/test/errors.js
@@ -45,7 +45,22 @@ describe("errors", function(){
         done()
       })
     })
+
+    it("should get error when import is not there", function(done){
+      poly.render("less/noimport.less", function(error, body){
+        should.not.exist(body)
+        should.exist(error)
+        error.should.have.property('source')
+        error.should.have.property('dest')
+        error.should.have.property('lineno', 1)
+        error.should.have.property('filename')
+        error.should.have.property('message')
+        error.should.have.property('stack', '@import \\"missing\\";', 'must escape quotes for CSS content')
+        done()
+      })
+    })
   })
+
 
   describe(".ejs", function(){
     it("should get error if var missing var", function(done){
@@ -179,6 +194,21 @@ describe("errors", function(){
         error.should.have.property('filename')
         error.should.have.property('message')
         error.should.have.property('stack')
+        done()
+      })
+    })
+
+    it("should get error when import is not there", function(done){
+      poly.render("styl/noimport.styl", function(error, body){
+        console.log(error)
+        should.not.exist(body)
+        should.exist(error)
+        error.should.have.property('source', "Stylus")
+        error.should.have.property('dest', "CSS")
+        error.should.have.property('lineno', 1)
+        error.should.have.property('filename')
+        error.should.have.property('message')
+        error.should.have.property('stack', '@import \\"missing\\";', 'must escape quotes for CSS content')
         done()
       })
     })

--- a/test/fixtures/errors/less/noimport.less
+++ b/test/fixtures/errors/less/noimport.less
@@ -1,0 +1,1 @@
+@import "missing";

--- a/test/fixtures/errors/styl/noimport.styl
+++ b/test/fixtures/errors/styl/noimport.styl
@@ -1,0 +1,1 @@
+@import "missing";


### PR DESCRIPTION
Progress on https://github.com/sintaxi/harp/issues/35.

This test doesn’t entirely cover the problem. Basically, messages in CSS `content` must have quotes escaped as `\"`, and should also have special characters like `&#8230;` (which is: &#8230;) escaped as Unicode like this: `\2026`. If that doesn’t happen, the CSS will be invalid and the error messages can easily get cut off.

So, I’m not entirely sure if the fix belongs in Terraform, Harp, or the future error view module. It might make sense that the error messages would be escaped in Terraform, but the only reason they’d need to be escaped this way is because they appear in CSS. The only thing determining that is Harp, so maybe this belongs there for now and the other module in the future. I had already made the test when this occurred to me, so here we are.
