### PR TITLE
Warning API or update Jade and corresponding tests for 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache" : "2.3.0",
-    "jade" : "0.35.0",
+    "jade" : "1.0.2",
     "coffee-script" : "1.6.3",
     "ejs" : "0.8.4",
     "node-sass": "0.7.0",

--- a/test/fixtures/render/layouts/explicit/_layout.jade
+++ b/test/fixtures/render/layouts/explicit/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
   body

--- a/test/fixtures/render/layouts/explicit/custom_layout.jade
+++ b/test/fixtures/render/layouts/explicit/custom_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
   body

--- a/test/fixtures/render/layouts/explicit/splash.jade
+++ b/test/fixtures/render/layouts/explicit/splash.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
   body

--- a/test/fixtures/render/layouts/implicit/_layout.jade
+++ b/test/fixtures/render/layouts/implicit/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
   body


### PR DESCRIPTION
Jade deprecated `!!!` for `doctype` in 1.0.0, [which is unfortunate](https://github.com/visionmedia/jade/pull/1270). It was also decided not to make it a warning, like with `script.`, but to actually throw an error.

I don’t necessarily think this should get merged, but we’ll have to deal with it at some point. It’s going to break every app written in Jade since we were advocating the `!!!` shorthand over `doctype` (I didn’t even know that was shorthand, to be honest).

If anything, it might indicate we need some way to throw our own warning pages, just like we do for errors. Then, when breaking API changes happen again, either in Harp like with `_data`, or in the preprocessors, like when LESS stopped working with Bootstrap 2 one, this issue, or whatever else, Harp could fail more gracefully. It would actually also be great for missing libsass features, too.
