### PR TITLE
browserify coffeescripts

### DIFF
--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -43,6 +43,13 @@ module.exports = function(root, filePath, callback){
 
     var render = processors[ext].compile(srcPath, data, function(err, script) {
       if (err) return callback(err)
+
+      /**
+       * Skip browserification if string does not contain
+       * any require() statements...
+       */
+      if (!script.match(/require ?\(/)) return callback(err, script)
+
       require('browserify-string')(script)
         .bundle(function (err, script) {
           callback(err, script)

--- a/lib/javascript/index.js
+++ b/lib/javascript/index.js
@@ -41,7 +41,13 @@ module.exports = function(root, filePath, callback){
      * Lookup Directories
      */
 
-    var render = processors[ext].compile(srcPath, data, callback)
+    var render = processors[ext].compile(srcPath, data, function(err, script) {
+      if (err) return callback(err)
+      require('browserify-string')(script)
+        .bundle(function (err, script) {
+          callback(err, script)
+        });
+    })
 
   })
 

--- a/lib/terraform.js
+++ b/lib/terraform.js
@@ -48,8 +48,8 @@ exports.root = function(root, globals){
     /**
      * Render
      *
-     * This is the main method to to render a view. This function is
-     * responsible to for figuring out the layout to use and sets the
+     * This is the main method to render a view. This function is
+     * responsible for figuring out the layout to use and sets the
      * `current` object.
      *
      */

--- a/package.json
+++ b/package.json
@@ -2,28 +2,44 @@
   "name": "terraform",
   "version": "0.6.2",
   "description": "pre-processor engine that powers the harp web server",
-  "repository" : { "type" : "git", "url" : "https://github.com/sintaxi/terraform.git" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sintaxi/terraform.git"
+  },
   "main": "./lib/terraform",
   "scripts": {
     "test": "mocha --reporter spec"
   },
   "author": "Brock Whitten <brock@chloi.io>",
   "contributors": [
-    { "name": "Brock Whitten", "email": "brock@chloi.io" },
-    { "name": "Brian Donovan", "email": "donovan@squareup.com" },
-    { "name": "Kenneth Ormandy", "email": "kenneth@chloi.io" },
-    { "name": "Zhang Yichao", "email": "echaozh@gmail.com" }
+    {
+      "name": "Brock Whitten",
+      "email": "brock@chloi.io"
+    },
+    {
+      "name": "Brian Donovan",
+      "email": "donovan@squareup.com"
+    },
+    {
+      "name": "Kenneth Ormandy",
+      "email": "kenneth@chloi.io"
+    },
+    {
+      "name": "Zhang Yichao",
+      "email": "echaozh@gmail.com"
+    }
   ],
   "license": "MIT",
   "dependencies": {
-    "lru-cache" : "2.3.0",
-    "jade" : "0.35.0",
-    "coffee-script" : "1.6.3",
-    "ejs" : "0.8.4",
+    "lru-cache": "2.3.0",
+    "jade": "0.35.0",
+    "coffee-script": "1.6.3",
+    "ejs": "0.8.4",
     "node-sass": "0.7.0",
     "marked": "0.2.9",
-    "less" : "1.5.1",
-    "stylus": "0.40.0"
+    "less": "1.5.1",
+    "stylus": "0.40.0",
+    "browserify-string": "0.0.3"
   },
   "devDependencies": {
     "mocha": "1.8.2",

--- a/test/fixtures/javascripts/coffee/browserify.coffee
+++ b/test/fixtures/javascripts/coffee/browserify.coffee
@@ -1,0 +1,1 @@
+should = require('should')

--- a/test/javascripts.js
+++ b/test/javascripts.js
@@ -25,6 +25,15 @@ describe("javascripts", function(){
       })
     })
 
+    it("should not browserify scripts that don't contain 'require' statements", function(done){
+      poly.render("main.coffee", function(errors, body){
+        should.not.exist(errors)
+        should.exist(body)
+        body.should.not.match(/typeof require=="function"/);
+        done()
+      })
+    })
+
     it("should return errors if invalid", function(done){
       poly.render("invalid.coffee", function(errors, body){
         should.exist(errors)

--- a/test/javascripts.js
+++ b/test/javascripts.js
@@ -15,6 +15,16 @@ describe("javascripts", function(){
       })
     })
 
+    it("should browserify coffeescripts", function(done){
+      poly.render("browserify.coffee", function(errors, body){
+        should.not.exist(errors)
+        should.exist(body)
+        body.should.match(/typeof require=="function"/);
+        body.should.match(/should = require\('should'\);/);
+        done()
+      })
+    })
+
     it("should return errors if invalid", function(done){
       poly.render("invalid.coffee", function(errors, body){
         should.exist(errors)


### PR DESCRIPTION
This branch adds browserify support to terraform's coffeescript compilation step. I've added tests and created a sample app to demo the behavior: https://github.com/zeke/harp-browserify-test

It would be ideal to also browserify regular old `.js` files too, but it wasn't immediately clear to me how to do that. Happy to make amendments to this PR with some guidance. :)

cc @sintaxi @michael-lawrence @kennethormandy @kevinsimper, because you all participated on https://github.com/sintaxi/harp/issues/55

PS I didn't revamp the `package.json` formatting on purpose. I think `npm` is doing that automatically.