### PR TITLE
Render markdown files encoded in UTF-8 with BOM

### DIFF
--- a/lib/template/processors/md.js
+++ b/lib/template/processors/md.js
@@ -6,7 +6,7 @@ module.exports = function(fileContents, options){
   return {
     compile: function(){
       return function (locals){
-        return marked(fileContents.toString())
+        return marked(fileContents.toString().replace(/^\uFEFF/, ''))
       }
     },
 

--- a/test/fixtures/templates/bom.md
+++ b/test/fixtures/templates/bom.md
@@ -1,0 +1,6 @@
+﻿# file with bom marker
+
+This file should have a BOM marker at the front of the file. This can be achieved with one of the following :-
+
+* Notepad++: Encoding -> Encode in UTF-8
+* Sublime Text: File -> Save With Encoding -> UTF-8 with BOM

--- a/test/templates.js
+++ b/test/templates.js
@@ -29,6 +29,15 @@ describe("templates", function(){
         done()
       })
     })
+
+    it("should render markdown file encoded in UTF-8 with BOM", function(done){
+      poly.render("bom.md", function(error, body){
+        should.not.exist(error)
+        should.exist(body)
+        body.should.include("<h1>file with bom marker</h1>")
+        done()
+      })
+    })
   })
 
   describe(".jade", function(){


### PR DESCRIPTION
Came across an issue with Harp when testing where the first line of a markdown file was not being parsed correctly. 

Turns out that Visual Studio 2013 saves UTF-8 files with a BOM marker by default. Buffer.toString() returns a string with the BOM marker in it, which in turn breaks marked. BOM markers in UTF-8 encoded files are redundant, so it is safe to strip them. 

I'm not entirely sure whether Git preserves file encodings (suspect they don't), so to make sure the tests are testing for the right thing, ensure that tests/fixtures/templates/bom.md is saved encoded as UTF-8 with BOM. This can be achieved with the following:
- **Notepad++**: Encoding -> Encode in UTF-8
- **Sublime Text**: File -> Save With Encoding -> UTF-8 with BOM
- **Visual Studio**: File -> Advanced Save Options -> Encoding = Unicode (UTF-8 with signature) - Codepage 65001

See [the Wikipedia page](http://en.wikipedia.org/wiki/UTF-8#Byte_order_mark) more information.
