### PR TITLE
Revert "changes coffeescript args to be bare"

### DIFF
--- a/lib/javascript/processors/coffee.js
+++ b/lib/javascript/processors/coffee.js
@@ -4,7 +4,7 @@ var TerraformError = require("../../error").TerraformError
 exports.compile = function(filePath, fileContents, callback){
   try{
     var errors = null
-    var script = cs.compile(fileContents.toString(), { bare: true })
+    var script = cs.compile(fileContents.toString())
   }catch(e){
     var errors = e
     errors.source = "CoffeeScript"


### PR DESCRIPTION
This reverts commit 5c5eaa2e0fffe8824f9269af454c8e5b7e8b17c3.

It's unexpected behaviour, as Coffeescript normally doesn't compile bare. And it's typically more fragile/dangerous.
