### PR TITLE
Use partial with preprocessors (failing)

### DIFF
--- a/test/fixtures/templates/inline.jade
+++ b/test/fixtures/templates/inline.jade
@@ -1,0 +1,5 @@
+style.
+  != partial("nest/inline.scss")
+
+script.
+  != partial("nest/inline.coffee")

--- a/test/fixtures/templates/nest/inline.coffee
+++ b/test/fixtures/templates/nest/inline.coffee
@@ -1,0 +1,1 @@
+alert "Hi"

--- a/test/fixtures/templates/nest/inline.scss
+++ b/test/fixtures/templates/nest/inline.scss
@@ -1,0 +1,5 @@
+$color: cornflowerblue;
+
+body {
+  background: $color;
+}

--- a/test/templates.js
+++ b/test/templates.js
@@ -77,6 +77,16 @@ describe("templates", function(){
       })
     })
 
+    it("should inline preprocessed files", function(done){
+      poly.render("inline.jade", function(error, body){
+        should.not.exist(error)
+        should.exist(body)
+        body.should.include("body{background:cornflowerblue}")
+        body.should.include("alert(\"Hi\")")
+        done()
+      })
+    })
+
   })
 
 })


### PR DESCRIPTION
This just adds a test, mostly to discuss.

It would be great to be able to use `partial` on the CSS and JS preprocessors, so you could inline Sass or CoffeeScript as appropriate. This is also the only thing holding Harp back from being useful for email templates. (You need to be able to inline the CSS into a `<style>` bock before you pass it onto something else.)

Right now you can only do this through Jade’s `include`, which means you can’t use preprocessors.
