### PR TITLE
Update jade to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.5.0",
-    "jade": "0.35.0",
+    "jade": "1.5.0",
     "coffee-script": "1.7.1",
     "ejs": "1.0.0",
     "node-sass": "0.9.3",


### PR DESCRIPTION
Jade has had a lot of fixes, improvements, and the odd breaking change since 0.35.0.  It would be really helpful to have people start using more up to date versions.