### PR TITLE
adding support for coffee source maps.

### DIFF
--- a/lib/javascript/processors/coffee.js
+++ b/lib/javascript/processors/coffee.js
@@ -4,7 +4,9 @@ var TerraformError = require("../../error").TerraformError
 exports.compile = function(filePath, fileContents, callback){
   try{
     var errors = null
-    var script = cs.compile(fileContents.toString(), { bare: true })
+    //source maps off by default, unless `NODE_ENV=dev harp server app.js` is run.
+    var useMaps = process.env.coffee_map || process.env.NODE_ENV=="dev"?true:false;
+    var script = cs.compile(fileContents.toString(), { bare: true , map : useMaps })
   }catch(e){
     var errors = e
     errors.source = "CoffeeScript"


### PR DESCRIPTION
This needs testing, but expected behaviour is when run on `dev` mode it should create sourceMaps automatically with coffee-script compiler.
