### PR TITLE
Fix getCurrent to work with folder and files with '.' in his names.

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -278,8 +278,9 @@ exports.getCurrent = function(sourcePath){
   // windows
   sourcePath = sourcePath.replace(/\\/g,'/')
 
-  // this could be a tad smarter
-  var namespace = sourcePath.split(".")[0].split("/")
+  var namespace = sourcePath.split("/")
+  var fnameSplit = namespace[namespace.length-1].split('.')
+  namespace[namespace.length-1] = fnameSplit.slice(0,fnameSplit.length-1).join('.')
 
   return {
     source: namespace[namespace.length -1],


### PR DESCRIPTION
I have a trouble when try to use folder with '.' in name. After search I found that problem is in this function getCurrent() from helpers. Simple realization not allow dots in file or folder name except file extension. This patch solve problem.