### PR TITLE
Updating less and marked packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,25 +12,45 @@
   },
   "author": "Brock Whitten <brock@chloi.io>",
   "contributors": [
-    { "name": "Brock Whitten", "email": "brock@chloi.io" },
-    { "name": "Brian Donovan", "email": "donovan@squareup.com" },
-    { "name": "Kenneth Ormandy", "email": "kenneth@chloi.io" },
-    { "name": "Zhang Yichao", "email": "echaozh@gmail.com" },
-    { "name": "Carlos Rodriguez" },
-    { "name": "Zeke Sikelianos", "email": "zeke@sikelianos.com" },
-    { "name": "Guilherme Rodrigues", "email": "gadr90@gmail.com" }
+    {
+      "name": "Brock Whitten",
+      "email": "brock@chloi.io"
+    },
+    {
+      "name": "Brian Donovan",
+      "email": "donovan@squareup.com"
+    },
+    {
+      "name": "Kenneth Ormandy",
+      "email": "kenneth@chloi.io"
+    },
+    {
+      "name": "Zhang Yichao",
+      "email": "echaozh@gmail.com"
+    },
+    {
+      "name": "Carlos Rodriguez"
+    },
+    {
+      "name": "Zeke Sikelianos",
+      "email": "zeke@sikelianos.com"
+    },
+    {
+      "name": "Guilherme Rodrigues",
+      "email": "gadr90@gmail.com"
+    }
   ],
   "license": "MIT",
   "dependencies": {
-    "lru-cache": "2.5.0",
-    "jade": "0.35.0",
+    "autoprefixer": "~2.2.0",
     "coffee-script": "1.7.1",
     "ejs": "1.0.0",
+    "jade": "0.35.0",
+    "less": "1.7.5",
+    "lru-cache": "2.5.0",
+    "marked": "0.3.2",
     "node-sass": "0.9.3",
-    "marked": "0.2.9",
-    "less": "1.7.4",
-    "stylus": "0.47.3",
-    "autoprefixer": "~2.2.0"
+    "stylus": "0.47.3"
   },
   "devDependencies": {
     "mocha": "1.8.2",


### PR DESCRIPTION
Still a few outdated modules, I only did the "risky" ones. Let me know if you want a new, generic bug for the other outdated modules.
Current output:
```sh
$ npm shrinkwrap --dev
wrote npm-shrinkwrap.json

$ nsp shrinkwrap
No vulnerable modules found

$ npm outdated --depth 0 | sort
Package        Current  Wanted     Latest  Location
autoprefixer     2.2.0   2.2.0      3.1.0  autoprefixer
coffee-script    1.7.1   1.7.1      1.8.0  coffee-script
jade            0.35.0  0.35.0      1.7.0  jade
mocha            1.8.2   1.8.2     1.21.4  mocha
node-sass        0.9.3   0.9.3  0.9.5-rc1  node-sass
should           1.2.2   1.2.2      4.0.4  should
stylus          0.47.3  0.47.3     0.49.1  stylus
```

Fixes #64