### PR TITLE
Add coffee-react (.cjsx) support

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -15,7 +15,7 @@ var TerraformError = exports.TerraformError = require("../error").TerraformError
 var processors = exports.processors = {
   "html": ["jade", "ejs", "md"],
   "css" : ["styl", "less", "scss", "sass"],
-  "js"  : ["coffee"]
+  "js"  : ["coffee", "cjsx"]
 }
 
 

--- a/lib/javascript/processors/cjsx.js
+++ b/lib/javascript/processors/cjsx.js
@@ -1,0 +1,20 @@
+var cs = require("coffee-react")
+var TerraformError = require("../../error").TerraformError
+
+exports.compile = function(filePath, fileContents, callback){
+  try{
+    var errors = null
+    var script = cs.compile(fileContents.toString(), { bare: true })
+  }catch(e){
+    var errors = e
+    errors.source = "CJSX"
+    errors.dest = "JavaScript"
+    errors.filename = filePath
+    errors.stack = fileContents.toString()
+    errors.lineno = parseInt(errors.location.first_line ? errors.location.first_line + 1 : -1)
+    var script = null
+    var error = new TerraformError(errors)
+  }finally{
+    callback(error, script)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,19 +18,21 @@
     { "name": "Zhang Yichao", "email": "echaozh@gmail.com" },
     { "name": "Carlos Rodriguez" },
     { "name": "Zeke Sikelianos", "email": "zeke@sikelianos.com" },
-    { "name": "Guilherme Rodrigues", "email": "gadr90@gmail.com" }
+    { "name": "Guilherme Rodrigues", "email": "gadr90@gmail.com" },
+    { "name": "Melchior Brislinger", "email": "mail@melchiorbrislinger.de" }
   ],
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.5.0",
     "jade": "0.35.0",
-    "coffee-script": "1.7.1",
     "ejs": "1.0.0",
     "node-sass": "0.9.3",
     "marked": "0.2.9",
     "less": "1.7.4",
     "stylus": "0.47.3",
-    "autoprefixer": "~2.2.0"
+    "autoprefixer": "~2.2.0",
+    "coffee-script": "1.8.0",
+    "coffee-react": "2.1.2"
   },
   "devDependencies": {
     "mocha": "1.8.2",

--- a/test/fixtures/javascripts/cjsx/invalid.cjsx
+++ b/test/fixtures/javascripts/cjsx/invalid.cjsx
@@ -1,0 +1,3 @@
+foo = function(){
+  <this>shouldnt<work>
+}

--- a/test/fixtures/javascripts/cjsx/main.cjsx
+++ b/test/fixtures/javascripts/cjsx/main.cjsx
@@ -1,0 +1,2 @@
+html = (x, y) ->
+  <div x={x}>{y}</div>

--- a/test/javascripts.js
+++ b/test/javascripts.js
@@ -28,4 +28,29 @@ describe("javascripts", function(){
 
   })
 
+  describe(".cjsx", function(){
+    var root = __dirname + "/fixtures/javascripts/cjsx"
+    var poly = polymer.root(root)
+
+    it("should translate cjsx to javascript", function(done){
+      poly.render("main.cjsx", function(errors, body){
+        should.not.exist(errors)
+        should.exist(body)
+        done()
+      })
+    })
+
+    it("should return errors if invalid", function(done){
+      poly.render("invalid.cjsx", function(errors, body){
+        should.exist(errors)
+        should.not.exist(body)
+        errors.should.have.property("name")
+        errors.should.have.property("message")
+        errors.should.have.property("stack")
+        done()
+      })
+    })
+
+  })
+
 })


### PR DESCRIPTION
This adds support for coffee-react files (https://github.com/jsdf/coffee-react).

These are coffee-script files with embedded HTML/JSX to be used, for example, with Facebook's React library.
