### PR TITLE
Update node-sass to 2.0.0-beta

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -278,8 +278,9 @@ exports.getCurrent = function(sourcePath){
   // windows
   sourcePath = sourcePath.replace(/\\/g,'/')
 
-  // this could be a tad smarter
-  var namespace = sourcePath.split(".")[0].split("/")
+  var namespace = sourcePath.split("/")
+  var fnameSplit = namespace[namespace.length-1].split('.')
+  namespace[namespace.length-1] = fnameSplit.slice(0,fnameSplit.length-1).join('.')
 
   return {
     source: namespace[namespace.length -1],

--- a/lib/stylesheet/processors/sass.js
+++ b/lib/stylesheet/processors/sass.js
@@ -6,17 +6,16 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     file: filePath,
     includePaths: dirs,
     success: function(css) {
-      callback(null, css);
+      callback(null, css.css);
     },
     error: function(e) {
-      var arr = e.split(":")
       var error = new TerraformError ({
         source: "Sass",
         dest: "CSS",
-        lineno: arr[1] || 99,
+        lineno: e.line || 99,
         name: "Sass Error",
-        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
-        filename: arr[0] || filePath,
+        message: e.message,
+        filename: e.file || filePath,
         stack: fileContents.toString()
       })
       return callback(error)

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -6,17 +6,16 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     file: filePath,
     includePaths: dirs,
     success: function(css) {
-      callback(null, css);
+      callback(null, css.css);
     },
     error: function(e) {
-      var arr = e.split(":")
       var error = new TerraformError ({
         source: "Sass",
         dest: "CSS",
-        lineno: arr[1] || 99,
+        lineno: e.line || 99,
         name: "Sass Error",
-        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
-        filename: arr[0] || filePath,
+        message: e.message,
+        filename: e.file || filePath,
         stack: fileContents.toString()
       })
       return callback(error)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jade": "0.35.0",
     "coffee-script": "1.7.1",
     "ejs": "1.0.0",
-    "node-sass": "0.9.3",
+    "node-sass": "^2.0.0",
     "marked": "0.2.9",
     "less": "1.7.4",
     "stylus": "0.47.3",

--- a/test/render.js
+++ b/test/render.js
@@ -188,7 +188,7 @@ describe("render(path, callback)", function(){
       poly.render("scss.scss", function(errors, body){
         should.not.exist(errors)
         should.exist(body)
-        body.should.include("body{background:#FF00AA;}")
+        body.should.include("body{background:#FF00AA}")
         done()
       })
     })


### PR DESCRIPTION
The version of node-sass currently included in terraform is more than 6 months old; node-sass has improved _immensely_ since then. 2.0.0 includes robust support for Sass maps, which would address [this issue over on Harp](https://github.com/sintaxi/harp/issues/329)

