### PR TITLE
Add fs.statSync to model.current (and fix some typos)

### DIFF
--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -27,7 +27,7 @@ helpers.processors["html"].forEach(function(sourceType){
  *
  * A closure to properly scope the `partial` function so that
  * we can pass the `partial` function into the template and it
- * will have access to the correct local varialbes.
+ * will have access to the correct local variables.
  *
  */
 

--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -73,6 +73,13 @@ var scope = module.exports = function(projectPath, parentLocals){
 
       if(!partialLocals) partialLocals = {}
 
+      /**
+       * If we're processing a file add file stat to current.
+       */
+      if (partialLocals.current) {
+        partialLocals.current.stat = fs.statSync(filePath)
+      }
+
 
       /**
        * Our local object that we will pass into the template.

--- a/lib/template/index.js
+++ b/lib/template/index.js
@@ -31,9 +31,9 @@ helpers.processors["html"].forEach(function(sourceType){
  *
  */
 
-var scope = module.exports = function(projectPath, partentLocals){
+var scope = module.exports = function(projectPath, parentLocals){
 
-  if(!partentLocals) partentLocals = {}
+  if(!parentLocals) parentLocals = {}
 
   return {
 
@@ -55,7 +55,7 @@ var scope = module.exports = function(projectPath, partentLocals){
 
       var filePath        = path.resolve(projectPath, relPath)
       var partialCurrent  = helpers.getCurrent(relPath)
-      var templateLocals  = helpers.walkData(partialCurrent.path, partentLocals.public)
+      var templateLocals  = helpers.walkData(partialCurrent.path, parentLocals.public)
       var fileContents    = fs.readFileSync(filePath)
       var ext             = path.extname(relPath).replace(/^\./, '')
 
@@ -85,8 +85,8 @@ var scope = module.exports = function(projectPath, partentLocals){
        * Add the parent locals.
        */
 
-      for(var local in partentLocals){
-        locals[local] = partentLocals[local]
+      for(var local in parentLocals){
+        locals[local] = parentLocals[local]
       }
 
 


### PR DESCRIPTION
The first two commits fix some minor typos.

The third commit adds `fs.statSync(...)` to model.current. This allows referencing the last modification time of the current file in a view or layout.

For example in a Jade template you can do something like:

```jade
p Last updated #{current.stat.mtime.toLocaleDateString()}
```

And have it automatically reflect the last update timestamp of the jade file, i.e. it'd render as:

```html
<p>Last updated 'Sunday, January 1, 2015</p>
```