### PR TITLE
Release v0.10.1

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -278,9 +278,8 @@ exports.getCurrent = function(sourcePath){
   // windows
   sourcePath = sourcePath.replace(/\\/g,'/')
 
-  var namespace = sourcePath.split("/")
-  var fnameSplit = namespace[namespace.length-1].split('.')
-  namespace[namespace.length-1] = fnameSplit.slice(0,fnameSplit.length-1).join('.')
+  // this could be a tad smarter
+  var namespace = sourcePath.split(".")[0].split("/")
 
   return {
     source: namespace[namespace.length -1],

--- a/lib/stylesheet/processors/sass.js
+++ b/lib/stylesheet/processors/sass.js
@@ -10,12 +10,13 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     },
     error: function(e) {
       var arr = e.split(":")
+      console.log(arr);
       var error = new TerraformError ({
         source: "Sass",
         dest: "CSS",
         lineno: arr[1] || 99,
         name: "Sass Error",
-        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
+        message: (arr[3] ? arr[2].replace("Backtrace", "").trim() + " " + arr[3].trim() : arr[2].trim()).replace(/"/g, '\\"'),
         filename: arr[0] || filePath,
         stack: fileContents.toString()
       })

--- a/lib/stylesheet/processors/sass.js
+++ b/lib/stylesheet/processors/sass.js
@@ -6,16 +6,17 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     file: filePath,
     includePaths: dirs,
     success: function(css) {
-      callback(null, css.css);
+      callback(null, css);
     },
     error: function(e) {
+      var arr = e.split(":")
       var error = new TerraformError ({
         source: "Sass",
         dest: "CSS",
-        lineno: e.line || 99,
+        lineno: arr[1] || 99,
         name: "Sass Error",
-        message: e.message,
-        filename: e.file || filePath,
+        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
+        filename: arr[0] || filePath,
         stack: fileContents.toString()
       })
       return callback(error)

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -6,16 +6,17 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     file: filePath,
     includePaths: dirs,
     success: function(css) {
-      callback(null, css.css);
+      callback(null, css);
     },
     error: function(e) {
+      var arr = e.split(":")
       var error = new TerraformError ({
         source: "Sass",
         dest: "CSS",
-        lineno: e.line || 99,
+        lineno: arr[1] || 99,
         name: "Sass Error",
-        message: e.message,
-        filename: e.file || filePath,
+        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
+        filename: arr[0] || filePath,
         stack: fileContents.toString()
       })
       return callback(error)

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -15,7 +15,7 @@ exports.compile = function(filePath, dirs, fileContents, callback){
         dest: "CSS",
         lineno: arr[1] || 99,
         name: "Sass Error",
-        message: (arr[4] ? arr[3].replace("Backtrace", "").trim() + " " + arr[4].trim() : arr[3].trim()).replace(/"/g, '\\"'),
+        message: (arr[3] ? arr[2].replace("Backtrace", "").trim() + " " + arr[3].trim() : arr[2].trim()).replace(/"/g, '\\"'),
         filename: arr[0] || filePath,
         stack: fileContents.toString()
       })

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jade": "0.35.0",
     "coffee-script": "^1.9.0",
     "ejs": "^1.0.0",
-    "node-sass": "^2.0.0-beta",
+    "node-sass": "^1.2.3",
     "marked": "^0.3.3",
     "less": "^1.7.5",
     "stylus": "0.47.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "marked": "^0.3.3",
     "less": "^1.7.5",
     "stylus": "0.47.3",
-    "minify": "git://github.com/ianstormtaylor/minify#0.2.0",
+    "minify": "git://github.com/kennethormandy/minify#v0.3.0",
     "autoprefixer": "5.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",

--- a/test/data.js
+++ b/test/data.js
@@ -27,6 +27,16 @@ describe("data", function(){
       })
     })
 
+    it("should handle escaped html", function(done){
+      poly.render("articles/hello-pluto.jade", function(error, body){
+        should.not.exist(error)
+        should.exist(body)
+        body.should.include("<h1><a href=\"http://harpjs.com\">Harp</a></h1>")
+        done()
+      })
+    })
+
+
     it("should be available to override data when calling partial", function(done){
       poly.render("index.jade", function(error, body){
         should.not.exist(error)

--- a/test/fixtures/data/valid/articles/_data.json
+++ b/test/fixtures/data/valid/articles/_data.json
@@ -6,5 +6,8 @@
   "hello-jupiter": {
     "title" : "I was born on Jupiter",
     "author": "Brock Whitten"
+  },
+  "hello-pluto": {
+    "title": "<a href=\"http://harpjs.com\">Harp</a>"
   }
 }

--- a/test/fixtures/data/valid/articles/hello-pluto.jade
+++ b/test/fixtures/data/valid/articles/hello-pluto.jade
@@ -1,0 +1,3 @@
+//- Testing whether you can write escaped markup inside `_data.json` files
+
+h1!= title 


### PR DESCRIPTION
- Removes `getCurrent()` supporting `.` files, which broke tests in Harp
- Downgrades from Node-sass 2.0.0-beta to the stable v1.2.3
- Updates Minifier library dependencies
- Adds passing test for escaped markup in `_data.json`