### PR TITLE
Updating jade version to 1.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.5.0",
-    "jade": "^1.9.2",
+    "jade": "git://github.com/najamkhn/jade",
     "coffee-script": "^1.9.0",
     "ejs": "^1.0.0",
     "node-sass": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.5.0",
-    "jade": "0.35.0",
+    "jade": "^1.9.2",
     "coffee-script": "^1.9.0",
     "ejs": "^1.0.0",
     "node-sass": "^1.2.3",

--- a/test/fixtures/render/internationalization/_layout.jade
+++ b/test/fixtures/render/internationalization/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title Internationalization

--- a/test/fixtures/render/layouts/explicit/_layout.jade
+++ b/test/fixtures/render/layouts/explicit/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body

--- a/test/fixtures/render/layouts/explicit/custom_layout.jade
+++ b/test/fixtures/render/layouts/explicit/custom_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body

--- a/test/fixtures/render/layouts/implicit/_layout.jade
+++ b/test/fixtures/render/layouts/implicit/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body

--- a/test/fixtures/templates/deprecated/jade/_layout.jade
+++ b/test/fixtures/templates/deprecated/jade/_layout.jade
@@ -1,0 +1,6 @@
+!!!
+html
+  head
+  body
+    h1 Default Layout
+    != yield

--- a/test/fixtures/templates/deprecated/jade/index.jade
+++ b/test/fixtures/templates/deprecated/jade/index.jade
@@ -1,0 +1,2 @@
+h2 Hello World
+

--- a/test/templates.js
+++ b/test/templates.js
@@ -58,6 +58,15 @@ describe("templates", function(){
 
   describe(".jade", function(){
 
+    it("should give deprecated !!! warning", function(done){
+      poly.render("deprecated/jade/index.jade", function(error, body){
+        should.not.exist(error)
+        should.exist('`!!!` is deprecated, you must now use `doctype`')
+        should.exist(body)
+        done()
+      })
+    })
+
     it("should have jade partial layout and include working", function(done){
       poly.render("index.jade", function(error, body){
         should.not.exist(error)


### PR DESCRIPTION
- Updating jade to latest version
- Fixing testcases, removing the deprecated jade syntax for doctype