### PR TITLE
Release v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     { "name": "Glen Maddern", "email": "glenmaddern@gmail.com" },
     { "name": "Jed Foster", "email": "jed@jedfoster.com" },
     { "name": "Sehrope Sarkuni", "email": "sehrope@jackdb.com" },
-    { "name": "Keiichiro Matsumoto", "email": "matsumos@gmail.com" }
+    { "name": "Keiichiro Matsumoto", "email": "matsumos@gmail.com" },
+    { "name": "Najam Khn", "email": "najamkhn@gmail.com" }
   ],
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "lru-cache": "2.5.0",
     "jade": "git://github.com/najamkhn/jade#v1.9.3-bc",
-    "coffee-script": "1.9.0",
+    "coffee-script": "1.9.1",
     "ejs": "1.0.0",
     "node-sass": "2.0.1",
     "marked": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,17 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.5.0",
-    "jade": "0.35.0",
+    "jade": "git://github.com/najamkhn/jade#v1.9.3-bc",
     "coffee-script": "1.9.0",
     "ejs": "1.0.0",
     "node-sass": "2.0.1",
     "marked": "0.3.3",
     "less": "1.7.5",
+    "coffee-script": "^1.9.0",
+    "ejs": "^1.0.0",
+    "node-sass": "^1.2.3",
+    "marked": "^0.3.3",
+    "less": "^1.7.5",
     "stylus": "0.47.3",
     "minify": "git://github.com/kennethormandy/minify#v0.3.0",
     "autoprefixer": "5.1.0"

--- a/package.json
+++ b/package.json
@@ -34,11 +34,6 @@
     "node-sass": "2.0.1",
     "marked": "0.3.3",
     "less": "1.7.5",
-    "coffee-script": "^1.9.0",
-    "ejs": "^1.0.0",
-    "node-sass": "^1.2.3",
-    "marked": "^0.3.3",
-    "less": "^1.7.5",
     "stylus": "0.47.3",
     "minify": "git://github.com/kennethormandy/minify#v0.3.0",
     "autoprefixer": "5.1.0"

--- a/test/fixtures/render/internationalization/_layout.jade
+++ b/test/fixtures/render/internationalization/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
     title Internationalization

--- a/test/fixtures/render/layouts/explicit/custom_layout.jade
+++ b/test/fixtures/render/layouts/explicit/custom_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body

--- a/test/fixtures/render/layouts/implicit/_layout.jade
+++ b/test/fixtures/render/layouts/implicit/_layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype html
 html
   head
   body

--- a/test/fixtures/templates/deprecated/jade/_layout.jade
+++ b/test/fixtures/templates/deprecated/jade/_layout.jade
@@ -1,4 +1,4 @@
-doctype html
+!!!
 html
   head
   body

--- a/test/fixtures/templates/deprecated/jade/index.jade
+++ b/test/fixtures/templates/deprecated/jade/index.jade
@@ -1,0 +1,2 @@
+h2 Hello World
+

--- a/test/templates.js
+++ b/test/templates.js
@@ -58,6 +58,15 @@ describe("templates", function(){
 
   describe(".jade", function(){
 
+    it("should give deprecated !!! warning", function(done){
+      poly.render("deprecated/jade/index.jade", function(error, body){
+        should.not.exist(error)
+        should.exist('`!!!` is deprecated, you must now use `doctype`')
+        should.exist(body)
+        done()
+      })
+    })
+
     it("should have jade partial layout and include working", function(done){
       poly.render("index.jade", function(error, body){
         should.not.exist(error)


### PR DESCRIPTION
- Updates Jade to v1.9.2 without breaking `!!!`, thanks a lot @najamkhn!
- Updates CoffeeScript

__TODO__

- [ ] Fork our own version of Jade v1.9.3-bc
- [ ] Improve details in Jade depreciation error message

__Deferred__

- Update LESS (Breaking API changes since v2.0.0)
- Updating Stylus (Breaking line number changes after v0.47.3)