### PR TITLE
do not render Jekyll style front-matter from markdown

### DIFF
--- a/lib/template/processors/md.js
+++ b/lib/template/processors/md.js
@@ -3,6 +3,8 @@ var TerraformError = require("../../error").TerraformError
 var marked = require("marked")
 var renderer = new marked.Renderer()
 
+var FRONT_MATTER_REGEX = /^---[\s\S]*?---/
+
 // This overrides Marked’s default headings with IDs,
 // since this changed after v0.2.9
 // https://github.com/sintaxi/harp/issues/328
@@ -15,7 +17,7 @@ module.exports = function(fileContents, options){
   return {
     compile: function(){
       return function (locals){
-        return marked(fileContents.toString().replace(/^\uFEFF/, ''), {
+        return marked(fileContents.toString().replace(/^\uFEFF/, '').replace(FRONT_MATTER_REGEX, ''), {
           renderer: renderer
         })
       }

--- a/test/fixtures/templates/front-matter.md
+++ b/test/fixtures/templates/front-matter.md
@@ -1,0 +1,12 @@
+---
+front-matter-key: front-matter-value
+---
+
+# file with front matter
+
+This file has Jekyll-style front-matter at the top - it should be stripped off before rendering.
+
+different heading markup style
+---
+
+Note that `---` can also be used for headings - ensure that front-matter matcher is non-greedy

--- a/test/templates.js
+++ b/test/templates.js
@@ -54,6 +54,18 @@ describe("templates", function(){
         done()
       })
     })
+
+    it("should strip off front-matter at the top of markdown file", function(done){
+      poly.render("front-matter.md", function(error, body){
+        should.not.exist(error)
+        should.exist(body)
+        body.should.include("<h1>file with front matter</h1>")
+        body.should.not.include("front-matter-key")
+        body.should.not.include("front-matter-value")
+        body.should.include("<h2>different heading markup style</h2>")
+        done()
+      })
+    })
   })
 
   describe(".jade", function(){


### PR DESCRIPTION
In light of https://github.com/sintaxi/harp/issues/97, not rendering front-matter already present is kind of a good thing?