### PR TITLE
change node-sass dependency to use beta tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jade": "git://github.com/harp/jade#v1.9.3-bc.2",
     "coffee-script": "1.9.2",
     "ejs": "1.0.0",
-    "node-sass": "3.0.0-beta.5",
+    "node-sass": "3.0.0@beta",
     "marked": "0.3.3",
     "less": "2.5.0",
     "stylus": "0.47.3",


### PR DESCRIPTION
The current beta of node-sass 3.0.0 works on SmartOS but beta-5 does not.