### PR TITLE
Update package.json with node-sass@3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jade": "git://github.com/harp/jade#v1.9.3-bc.2",
     "coffee-script": "1.9.2",
     "ejs": "1.0.0",
-    "node-sass": "3.0.0-beta.5",
+    "node-sass": "3.3.2",
     "marked": "0.3.3",
     "less": "2.5.0",
     "stylus": "0.47.3",


### PR DESCRIPTION
This fixed segfault errors when compiling with sass on node 4. Also fixes #88, #91 and #100.

Given the nature of node 4, I think it's urgent that this project stay usable to those who are using the latest version.