### PR TITLE
Release v0.12.1

### DIFF
--- a/lib/stylesheet/index.js
+++ b/lib/stylesheet/index.js
@@ -1,8 +1,9 @@
 var path         = require("path")
 var fs           = require("fs")
 var helpers      = require('../helpers')
+var postcss      = require('postcss')
 var autoprefixer = require('autoprefixer')
-var minify = require('harp-minify')
+var minify       = require('harp-minify')
 
 /**
  * Build Processor list for stylesheets.
@@ -60,8 +61,12 @@ module.exports = function(root, filePath, callback){
       /**
        * Autoprefix, then consistently minify
        */
-      var post = minify.css(autoprefixer.process(css).css);
-      callback(null, post);
+      postcss([autoprefixer]).process(css).then(function (result) {
+        result.warnings().forEach(function (warn) {
+          console.warn(warn.toString())
+        })
+        callback(null, minify.css(result.css))
+      })
     })
 
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "0.11.0",
+  "version": "0.12.1",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "lru-cache": "2.6.5",
+    "lru-cache": "2.7.0",
     "harp-jade": "1.9.3-bc.4",
     "coffee-script": "1.10.0",
     "node-sass": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "less": "2.5.1",
     "stylus": "0.47.3",
     "harp-minify": "0.3.3",
-    "autoprefixer": "5.2.0"
+    "autoprefixer": "5.2.0",
+    "postcss": "5.0.5"
   },
   "devDependencies": {
     "mocha": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "marked": "0.3.5",
     "less": "2.5.1",
     "stylus": "0.47.3",
-    "harp-minify": "0.3.2",
+    "harp-minify": "0.3.3",
     "autoprefixer": "5.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lru-cache": "2.7.0",
     "harp-jade": "1.9.3-bc.4",
     "coffee-script": "1.10.0",
-    "node-sass": "3.3.2",
+    "node-sass": "3.3.3",
     "ejs": "2.3.4",
     "marked": "0.3.5",
     "less": "2.5.1",


### PR DESCRIPTION
- Bumps version number in `package.json` to v0.12.1
- Updates [Minify to v0.3.3](https://www.npmjs.com/package/harp-minify) for UglifyJS2 updates
- Updates LRU Cache
- Updates [Sass to v3.3.3](https://github.com/sass/node-sass/releases/tag/v3.3.3)
- Updates Autoprefixer to run as a PostCSS plugin, fixing deprecation warnings