### PR TITLE
Expose lodash to templates

### DIFF
--- a/lib/terraform.js
+++ b/lib/terraform.js
@@ -4,7 +4,7 @@ var stylesheet  = require('./stylesheet')
 var template    = require('./template')
 var javascript  = require('./javascript')
 var helpers     = require('./helpers')
-
+var lodash = require('lodash')
 
 /**
  * Expose Helpers
@@ -82,7 +82,7 @@ exports.root = function(root, globals){
         /**
          * Current
          */
-
+        locals._ = lodash
         locals.current = helpers.getCurrent(filePath)
 
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ejs": "2.3.4",
     "marked": "0.3.5",
     "less": "2.5.1",
+    "lodash": "3.10.1",
     "stylus": "0.47.3",
     "harp-minify": "0.3.3",
     "autoprefixer": "5.2.0",


### PR DESCRIPTION
This PR requires lodash.js and adds it to the `locals` object passed to templates, for more powerful data manipulation in `.jade` and `.ejs`