### PR TITLE
Release v0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ os: Windows Server 2012 R2
 # Test against this version of Node.js
 environment:
   matrix:
-  - nodejs_version: "0.10"
   - nodejs_version: "0.12"
   - nodejs_version: "4.0"
 

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
     "lru-cache": "2.7.0",
     "harp-jade": "1.9.3-bc.4",
     "coffee-script": "1.10.0",
-    "node-sass": "3.3.3",
+    "node-sass": "3.4.0-beta.2",
     "ejs": "2.3.4",
     "marked": "0.3.5",
-    "less": "2.5.1",
     "lodash": "3.10.1",
+    "less": "2.5.3",
     "stylus": "0.47.3",
     "harp-minify": "0.3.3",
-    "autoprefixer": "5.2.0",
-    "postcss": "5.0.5"
+    "autoprefixer": "6.0.3",
+    "postcss": "5.0.10"
   },
   "devDependencies": {
     "mocha": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Updates Sass
- Updates LESS
- Updates Autoprefixer / PostCSS (drops Node v0.10.x support)
- Updates CI settings (drops Node v0.10.x, adds v4.0.0)