### PR TITLE
bump jade version

### DIFF
--- a/lib/template/processors/jade.js
+++ b/lib/template/processors/jade.js
@@ -1,4 +1,4 @@
-var jade = require('harp-jade')
+var jade = require('jade')
 var TerraformError = require("../../error").TerraformError
 
 module.exports = function(fileContents, options){

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "lru-cache": "2.7.0",
-    "harp-jade": "1.9.3-bc.4",
+    "jade": "1.11.0",
     "coffee-script": "1.10.0",
     "node-sass": "3.3.3",
     "ejs": "2.3.4",


### PR DESCRIPTION
Updated jade to current version; fixes https://github.com/sintaxi/terraform/issues/114

All tests are passing except the one where it should warn against use of `!!!` rather than doctype; weird, cause I know there are a bunches of issues there. Maybe it's been undone?