### PR TITLE
Set locals correctly for files with dots in the path. 

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -279,7 +279,7 @@ exports.getCurrent = function(sourcePath){
   sourcePath = sourcePath.replace(/\\/g,'/')
 
   // this could be a tad smarter
-  var namespace = sourcePath.split(".")[0].split("/")
+  var namespace = sourcePath.split('.').slice(0, -1).join('.').split('/')
 
   return {
     source: namespace[namespace.length -1],

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -187,7 +187,7 @@ describe("helpers", function(){
       reply.should.be.true
       done()
     })
-    
+
     it('should ignore .git dirs', function(done){
       var reply = polymer.helpers.shouldIgnore(path.join('.git', 'foo.json'))
       reply.should.be.true
@@ -266,6 +266,24 @@ describe("helpers", function(){
 
   describe('.layoutCascade(filename)', function(){
 
+  })
+
+  describe('.getCurrent(sourcePath)', function(){
+    it('should handle folders', function(done){
+        polymer.helpers.getCurrent('a/b/c.md').should.eql({
+            'source': 'c',
+            'path': ['a', 'b', 'c']
+        })
+        done()
+    })
+
+    it('should handle dots in sourcePath.', function(done){
+        polymer.helpers.getCurrent('v1.3.3.7/1.0/doc.md').should.eql({
+            'source': 'doc',
+            'path': ['v1.3.3.7', '1.0', 'doc']
+        })
+        done()
+    })
   })
 
 })


### PR DESCRIPTION
I ran into while using Harp for a documentation site. 

Our folders have dots in the path for the versions eg. `/v2.0/docs/some-cool-doc` and I noticed the locals data wasn't being correctly set. Debugging lead me here:

* https://github.com/sintaxi/terraform/blob/f273c1970030d85226026c225bce26c7a757bc8e/lib/terraform.js#L86

This change makes `getCurrent` correctly handle files with dots in them. Very exciting.

Maybe sorta related to #31.