### PR TITLE
Adding sourcemaps for .scss in order to facilitate sourcemap support …

### DIFF
--- a/lib/stylesheet/index.js
+++ b/lib/stylesheet/index.js
@@ -55,17 +55,23 @@ module.exports = function(root, filePath, callback){
     /**
      * Lookup Directories
      */
-    var render = processors[ext].compile(srcPath, dirs, data, function(err, css) {
+    var render = processors[ext].compile(srcPath, dirs, data, function(err, css, sourcemap) {
       if (err) return callback(err);
 
       /**
        * Autoprefix, then consistently minify
        */
-      postcss([autoprefixer]).process(css).then(function (result) {
+      postcss([autoprefixer]).process(css, {map: {
+          inline: false, 
+          prev: sourcemap,
+          annotation: false
+        }
+        }).then(function (result) {
         result.warnings().forEach(function (warn) {
           console.warn(warn.toString())
         })
-        callback(null, minify.css(result.css))
+
+        callback(null, minify.css(result.css), result.map)
       })
     })
 

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -5,7 +5,12 @@ exports.compile = function(filePath, dirs, fileContents, callback){
   scss.render({
     file: filePath,
     includePaths: dirs,
-    outputStyle: 'compressed'
+    outputStyle: 'compressed',
+    sourceMap: true,
+    sourceMapEmbed: false,
+    sourceMapContents: true,
+    outFile: filePath,
+    omitSourceMapUrl: true
   }, function (e, css) {
     if (e) {
       var error = new TerraformError ({
@@ -19,7 +24,6 @@ exports.compile = function(filePath, dirs, fileContents, callback){
       })
       return callback(error)
     }
-
-    callback(null, css.css)
+    callback(null, css.css, css.map.toString())
   });
 }

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -96,6 +96,22 @@ describe("stylesheets", function(){
         done()
       })
     })
+    it("should render a source map", function(done){
+      poly.render("main.scss", function(error, body, sourcemap){
+        should.not.exist(error)
+        should.exist(sourcemap)
+        sourcemap.toString().should.include('main.scss')
+        sourcemap.toString().should.include('_part.scss')
+        done()
+      })
+    })
+    it("should not include the source map in the css body", function(done){
+      poly.render("main.scss", function(error, body, sourcemap){
+        should.not.exist(error)
+        body.should.not.include("/*#")
+        done()
+      })
+    })
 
   })
 


### PR DESCRIPTION
…in Harp: https://github.com/sintaxi/harp/issues/74.

How I'm currently implementing in a test project using terraform as a dependency:
```javascript
planet.render('main.scss', { "title": "Override the global title" }, function(error, body, sourcemap){
  fs.writeFile(__dirname + '/main.css', body + '\n/*# sourceMappingURL=main.css.map */')
  fs.writeFile(__dirname + '/main.css.map', sourcemap)
});
```