### PR TITLE
Feature/sourcemaps/all

### DIFF
--- a/lib/stylesheet/index.js
+++ b/lib/stylesheet/index.js
@@ -55,17 +55,23 @@ module.exports = function(root, filePath, callback){
     /**
      * Lookup Directories
      */
-    var render = processors[ext].compile(srcPath, dirs, data, function(err, css) {
+    var render = processors[ext].compile(srcPath, dirs, data, function(err, css, sourcemap) {
       if (err) return callback(err);
 
       /**
        * Autoprefix, then consistently minify
        */
-      postcss([autoprefixer]).process(css).then(function (result) {
+      postcss([autoprefixer]).process(css, {map: {
+          inline: false, 
+          prev: sourcemap,
+          annotation: false
+        }
+        }).then(function (result) {
         result.warnings().forEach(function (warn) {
           console.warn(warn.toString())
         })
-        callback(null, minify.css(result.css))
+
+        callback(null, minify.css(result.css), result.map)
       })
     })
 

--- a/lib/stylesheet/processors/less.js
+++ b/lib/stylesheet/processors/less.js
@@ -18,10 +18,11 @@ exports.compile = function(filePath, dirs, fileContents, callback){
   less.render(fileContents.toString(), {
       paths: dirs,            // Specify search paths for @import directives
       filename: filePath,     // Specify a filename, for better error messages
-      compress: false         // Minify CSS output
+      compress: false,         // Minify CSS output
+      sourceMap: true
     }, function(e, css){
       if (e) return callback(formatError(e))
-      return callback(null, css.css)
+      return callback(null, css.css, css.map.toString())
   })
 }
 

--- a/lib/stylesheet/processors/sass.js
+++ b/lib/stylesheet/processors/sass.js
@@ -5,7 +5,12 @@ exports.compile = function(filePath, dirs, fileContents, callback){
   sass.render({
     file: filePath,
     includePaths: dirs,
-    outputStyle: 'compressed'
+    outputStyle: 'compressed',
+    sourceMap: true,
+    sourceMapEmbed: false,
+    sourceMapContents: true,
+    outFile: filePath,
+    omitSourceMapUrl: true
   }, function (e, css) {
     if (e) {
       var error = new TerraformError ({
@@ -19,7 +24,7 @@ exports.compile = function(filePath, dirs, fileContents, callback){
       })
       return callback(error)
     }
-
-    callback(null, css.css)
+    
+    callback(null, css.css, css.map.toString())
   });
 }

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -5,7 +5,12 @@ exports.compile = function(filePath, dirs, fileContents, callback){
   scss.render({
     file: filePath,
     includePaths: dirs,
-    outputStyle: 'compressed'
+    outputStyle: 'compressed',
+    sourceMap: true,
+    sourceMapEmbed: false,
+    sourceMapContents: true,
+    outFile: filePath,
+    omitSourceMapUrl: true
   }, function (e, css) {
     if (e) {
       var error = new TerraformError ({
@@ -19,7 +24,6 @@ exports.compile = function(filePath, dirs, fileContents, callback){
       })
       return callback(error)
     }
-
-    callback(null, css.css)
+    callback(null, css.css, css.map.toString())
   });
 }

--- a/lib/stylesheet/processors/styl.js
+++ b/lib/stylesheet/processors/styl.js
@@ -3,32 +3,39 @@ var TerraformError = require("../../error").TerraformError
 
 
 exports.compile = function(filePath, dirs, fileContents, callback){
-  stylus.render(fileContents.toString(), {
-    filename: filePath,
-    paths: dirs,
-    compress: true,
-    'include css': true
-  }, function(err, css){
-    if(err){
-      // we are reverse engineering this formatException() function...
-      // https://github.com/LearnBoost/stylus/blob/master/lib/utils.js#L86
+  var style = stylus(fileContents.toString())
+    style.set('filename', filePath)
+    style.set('paths', dirs)
+    style.set('compress', true)
+    style.set('include css', true)
+    style.set('sourcemap', {
+      'comment': false,
+      'inline': false
+    })
 
-      var chunks    = err.message.split('\n\n')
-      var arr       = chunks[0].split('\n')
+    style.render(function(err, css){
 
-      err.filename  = parseInt(arr[0].split(':')[0] || -1)
-      var path_arr  = arr[0].split(':')
-      err.lineno    = parseInt(err.lineno || path_arr[path_arr.length -2] || -1)
-      var arr2      = chunks[1].split('\n')
-      err.message   = arr2[0].replace(/"/g, '\\"')
-      err.source    = "Stylus"
-      err.dest      = "CSS"
-      err.name      = "Stylus Error"
-      err.filename  = filePath
-      err.stack     = fileContents.toString()
-      var error     = new TerraformError(err)
-    }
+      if(err){
+        // we are reverse engineering this formatException() function...
+        // https://github.com/LearnBoost/stylus/blob/master/lib/utils.js#L86
 
-    callback(error, css)
-  })
+        var chunks    = err.message.split('\n\n')
+        var arr       = chunks[0].split('\n')
+        err.filename  = parseInt(arr[0].split(':')[0] || -1)
+        var path_arr  = arr[0].split(':')
+        err.lineno    = parseInt(err.lineno || path_arr[path_arr.length -2] || -1)
+        var arr2      = chunks[1].split('\n')
+        err.message   = arr2[0].replace(/"/g, '\\"')
+        err.source    = "Stylus"
+        err.dest      = "CSS"
+        err.name      = "Stylus Error"
+        err.filename  = filePath
+        err.stack     = fileContents.toString()
+        console.log(err);
+        var error     = new TerraformError(err)
+      }
+
+    callback(error, css, style.sourcemap)
+  });
+
 }

--- a/lib/stylesheet/processors/styl.js
+++ b/lib/stylesheet/processors/styl.js
@@ -18,7 +18,7 @@ exports.compile = function(filePath, dirs, fileContents, callback){
 
       err.filename  = parseInt(arr[0].split(':')[0] || -1)
       var path_arr  = arr[0].split(':')
-      err.lineno    = parseInt(err.lineno || path_arr[path_arr.length -1] || -1)
+      err.lineno    = parseInt(err.lineno || path_arr[path_arr.length -2] || -1)
       var arr2      = chunks[1].split('\n')
       err.message   = arr2[0].replace(/"/g, '\\"')
       err.source    = "Stylus"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "marked": "0.3.5",
     "lodash": "3.10.1",
     "less": "2.5.3",
-    "stylus": "0.47.3",
+    "stylus": "0.53.0",
     "harp-minify": "0.3.3",
     "autoprefixer": "6.1.0",
     "postcss": "5.0.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "pre-processor engine that powers the harp web server",
   "repository": {
     "type": "git",

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -31,6 +31,23 @@ describe("stylesheets", function(){
       })
     })
 
+    it("should render a source map", function(done){
+      poly.render("main.less", function(error, body, sourcemap){
+        should.not.exist(error)
+        should.exist(sourcemap)
+        sourcemap.toString().should.include('main.less')
+        sourcemap.toString().should.include('_part.less')
+        done()
+      })
+    })
+    it("should not include the source map in the css body", function(done){
+      poly.render("main.less", function(error, body, sourcemap){
+        should.not.exist(error)
+        body.should.not.include("/*#")
+        done()
+      })
+    })
+
   })
 
   describe(".styl", function(){

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -96,6 +96,22 @@ describe("stylesheets", function(){
         done()
       })
     })
+    it("should render a source map", function(done){
+      poly.render("main.scss", function(error, body, sourcemap){
+        should.not.exist(error)
+        should.exist(sourcemap)
+        sourcemap.toString().should.include('main.scss')
+        sourcemap.toString().should.include('_part.scss')
+        done()
+      })
+    })
+    it("should not include the source map in the css body", function(done){
+      poly.render("main.scss", function(error, body, sourcemap){
+        should.not.exist(error)
+        body.should.not.include("/*#")
+        done()
+      })
+    })
 
   })
 

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -81,6 +81,23 @@ describe("stylesheets", function(){
       })
     })
 
+    it("should render a source map", function(done){
+      poly.render("main.styl", function(error, body, sourcemap){
+        should.not.exist(error)
+        should.exist(sourcemap)
+        sourcemap.toString().should.include('main.styl')
+        sourcemap.toString().should.include('_part.styl')
+        done()
+      })
+    })
+    it("should not include the source map in the css body", function(done){
+      poly.render("main.styl", function(error, body, sourcemap){
+        should.not.exist(error)
+        body.should.not.include("/*#")
+        done()
+      })
+    })
+
   })
 
   describe(".scss", function(){

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -144,6 +144,23 @@ describe("stylesheets", function(){
       })
     })
 
+    it("should render a source map", function(done){
+      poly.render("main.sass", function(error, body, sourcemap){
+        should.not.exist(error)
+        should.exist(sourcemap)
+        sourcemap.toString().should.include('main.sass')
+        sourcemap.toString().should.include('_part.sass')
+        done()
+      })
+    })
+    it("should not include the source map in the css body", function(done){
+      poly.render("main.sass", function(error, body, sourcemap){
+        should.not.exist(error)
+        body.should.not.include("/*#")
+        done()
+      })
+    })
+
   })
 
   // Test for using partial for preprocessed CSS


### PR DESCRIPTION
Per @sintaxi's request here https://github.com/sintaxi/terraform/pull/120#issuecomment-160206915 - all supported stylesheet preprocessors (less, sass, scss, and styl) receive uniform sourcemap implementation here.

Previous scss-only pull request: https://github.com/sintaxi/terraform/pull/120
Open issue in Harp: https://github.com/sintaxi/harp/issues/74#issuecomment-160199105

Please note that Stylus required an updated version in order to play ball here. I called it out in the commit -- I'm pretty ignorant of that particular preprocessor and would appreciate a second set of eyes as the error reporting appeared to have changed between the two versions. Tests are passing now but I'm not sure if anything else is amiss.