### PR TITLE
Adds Eyeglass support to Terraform

### DIFF
--- a/lib/stylesheet/processors/sass.js
+++ b/lib/stylesheet/processors/sass.js
@@ -1,8 +1,9 @@
 var sass = require("node-sass")
+var eyeglass = require("eyeglass")
 var TerraformError = require("../../error").TerraformError
 
 exports.compile = function(filePath, dirs, fileContents, callback){
-  sass.render({
+  var opts = {
     file: filePath,
     includePaths: dirs,
     outputStyle: 'compressed',
@@ -10,8 +11,15 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     sourceMapEmbed: false,
     sourceMapContents: true,
     outFile: filePath,
-    omitSourceMapUrl: true
-  }, function (e, css) {
+    omitSourceMapUrl: true,
+    eyeglass: {
+      engines: {
+        sass: sass
+      }
+    }
+  }
+
+  sass.render(eyeglass(opts), function (e, css) {
     if (e) {
       var error = new TerraformError ({
         source: "Sass",
@@ -24,7 +32,7 @@ exports.compile = function(filePath, dirs, fileContents, callback){
       })
       return callback(error)
     }
-    
+
     callback(null, css.css, css.map.toString())
   });
 }

--- a/lib/stylesheet/processors/scss.js
+++ b/lib/stylesheet/processors/scss.js
@@ -1,8 +1,9 @@
 var scss = require("node-sass")
+var eyeglass = require("eyeglass")
 var TerraformError = require("../../error").TerraformError
 
 exports.compile = function(filePath, dirs, fileContents, callback){
-  scss.render({
+  var opts = {
     file: filePath,
     includePaths: dirs,
     outputStyle: 'compressed',
@@ -10,8 +11,15 @@ exports.compile = function(filePath, dirs, fileContents, callback){
     sourceMapEmbed: false,
     sourceMapContents: true,
     outFile: filePath,
-    omitSourceMapUrl: true
-  }, function (e, css) {
+    omitSourceMapUrl: true,
+    eyeglass: {
+      engines: {
+        sass: scss
+      }
+    }
+  }
+
+  scss.render(eyeglass(opts), function (e, css) {
     if (e) {
       var error = new TerraformError ({
         source: "Sass",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "through": "2.3.8"
   },
   "devDependencies": {
+    "eyeglass": "0.8.0",
+    "eyeglass-sample": "0.0.3",
     "mocha": "2.3.4",
     "should": "1.2.2"
   }

--- a/test/fixtures/stylesheets/sass/eyeglass.sass
+++ b/test/fixtures/stylesheets/sass/eyeglass.sass
@@ -1,0 +1,4 @@
+@import "eyeglass-sample"
+
+.sass:before
+  content: hello("Kenneth")

--- a/test/fixtures/stylesheets/scss/eyeglass.scss
+++ b/test/fixtures/stylesheets/scss/eyeglass.scss
@@ -1,0 +1,7 @@
+@import "eyeglass-sample";
+
+body {
+  &:before {
+    content: hello("Kenneth")
+  }
+}

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -205,6 +205,18 @@ describe("stylesheets", function(){
         done()
       })
     })
+    it("should include an SCSS Eyeglass module in a Sass file", function (done) {
+      poly.render("eyeglass.sass", function(error, body, sourcemap) {
+        should.not.exist(error)
+        should.exist(body)
+        should.exist(sourcemap)
+        body.should.include("Kenneth")
+        body.should.include("hello")
+        body.should.include(".sassy")
+        done()
+      })
+    })
+
 
   })
 

--- a/test/stylesheets.js
+++ b/test/stylesheets.js
@@ -146,6 +146,17 @@ describe("stylesheets", function(){
         done()
       })
     })
+    it("should include an Eyeglass module in an SCSS file", function (done) {
+      poly.render("eyeglass.scss", function(error, body, sourcemap) {
+        should.not.exist(error)
+        should.exist(body)
+        should.exist(sourcemap)
+        body.should.include("Kenneth")
+        body.should.include("hello")
+        body.should.include(".sassy")
+        done()
+      })
+    })
 
   })
 


### PR DESCRIPTION
This adds Eyeglass support to Terraform for `.scss` files, closing #103.

Ideally, we will also have this supported for `.sass` files. This PR includes a test for that as well, which works, but breaks `.sass` support in the process. Seems like if a `.sass` file is using an Eyeglass feature, it’s fine, but otherwise this breaks their complication.