### PR TITLE
Babel Support

### DIFF
--- a/lib/javascript/processors/js.js
+++ b/lib/javascript/processors/js.js
@@ -1,3 +1,7 @@
-exports.compile = function(filePath, fileContents, callback){
-	callback(null, fileContents.toString())
+var babel = require("babel-core")
+
+
+exports.compile = function(filePath, fileContents, callback) {
+    script = babel.transform(fileContents.toString(), {filename: '.babelrc', 'compact': true}).code
+    callback(null, script)
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "6.2.3",
+    "babel-core": "6.7.7",
     "browserify": "12.0.1",
     "coffee-script": "1.10.0",
     "ejs": "2.3.4",

--- a/test/fixtures/javascripts/babel/example.js
+++ b/test/fixtures/javascripts/babel/example.js
@@ -1,0 +1,6 @@
+var jsthing = 'I am some JS';
+var foo = function() {
+	var bar = 1 + 1;
+}
+
+foo();

--- a/test/javascripts.js
+++ b/test/javascripts.js
@@ -3,6 +3,19 @@ var polymer   = require('../')
 
 describe("javascripts", function(){
 
+  describe("babel", function() {
+    var root = __dirname + "/fixtures/javascripts/babel"
+    var poly = polymer.root(root)
+
+    it("should return same js when run without .babelrc", function(done) {
+      poly.render("example.js", function(errors, body) {
+        should.not.exist(errors)
+        body.should.equal('var jsthing="I am some JS";var foo=function(){var bar=1+1};foo();')
+        done()
+      })
+    })
+  })
+
   describe(".coffee", function(){
     var root = __dirname + "/fixtures/javascripts/coffee"
     var poly = polymer.root(root)


### PR DESCRIPTION
This PR seeks to provide a another attempt at Babel support,
in this case taking advantage of the fact that Babel out of the
box does nothing, and leaves configuration to the user.

Like #82, this implements Babel through a JavaScript processor,
but the difference is it does not implement it for .es files,
but instead replaces the default js processor with one that
_always_ gets run through Babel. As mentioned, this does nothing
by default, which means users should notice no difference.

With the addition of a .babelrc file in the directory they run
harp from as well as installation of requisite packages, the
user can activate Babel's features - which means they can
do anything ES6 support, JSX support, the whole bag.

Some notes:
- This seems to work with JSX despite the note in #127.
- #82 sought to provide some more fancy error handling, but in trying to replicate that I found it could swallow syntax errors that prevented js from being returned at all.
- I tried to create a test to confirm that with a .babelrc JSX would be properly transpiled, but I couldn't find a good way to do a test with a dot file short of introducing some mock library. Ideas welcome (or just an okay to add a mock library).
- Speaking to the discussion on file extension naming, Babel these days in their examples seems to expect people to run it against .js files.

A simple example is illustrative.

```
$ harp init .
$ npm init  # Create a simple package.json
$ npm install babel-preset-react react react-dom
```

Add the following to .babelrc:

```
 {
    "presets": [
      "react"
    ],
}
```

Now, edit _layout.jade:

```
doctype
html
  head
    link(rel="stylesheet" href="/main.css")
  body
    != yield
    script(src="/example.js")
```

Edit index.jade:

```
h1 Welcome to Harp<span id="babel"></span>.
h3 This is yours to own. Enjoy.
```

Finally you can try it without Babel, this will work without the .babelrc - add an example.js with:

```
document.getElementById('babel').innerHTML = ' (without Babel goodness)'
```

Run Harp, you should see the expected page. Now try some simple React in example.js instead (ensure your .babelrc is set up):

```
var React = require('react')
var ReactDOM = require('react-dom')

var Goodness = React.createClass({
  render: function() {
    return <em> (with Babel goodness)</em>;
  }
});

ReactDOM.render(
    <Goodness />,
    document.getElementById('babel')
)
```

That should do it.
