### PR TITLE
Update node-sass@v3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "3.10.1",
     "lru-cache": "4.0.0",
     "marked": "0.3.5",
-    "node-sass": "3.4.2",
+    "node-sass": "3.7.0",
     "postcss": "5.0.14",
     "stylus": "0.53.0",
     "through": "2.3.8"


### PR DESCRIPTION
The current locked version, v3.4.2, is very old and no longer supported. 
It also does not support Node 6. 
This causing many people issues including harp users.

https://github.com/sintaxi/harp/issues/556