### PR TITLE
use headerIds to remove header IDs

### DIFF
--- a/lib/template/processors/md.js
+++ b/lib/template/processors/md.js
@@ -5,24 +5,15 @@ var marked = require("marked").setOptions({
   headerPrefix: '',
   gfm: true,
   tables: true,
+  headerIds: false,
 })
-var renderer = new marked.Renderer()
-
-// This overrides Marked’s default headings with IDs,
-// since this changed after v0.2.9
-// https://github.com/sintaxi/harp/issues/328
-renderer.heading = function(text, level){
-  return '<h' + level + '>' +  text + '</h' + level + '>'
-}
 
 module.exports = function(fileContents, options){
 
   return {
     compile: function(){
       return function (locals){
-        return marked(fileContents.toString().replace(/^\uFEFF/, ''), {
-          renderer: renderer
-        })
+        return marked(fileContents.toString().replace(/^\uFEFF/, ''), options)
       }
     },
 


### PR DESCRIPTION
Instead of overrides `marked`'s default header with IDs using the renderer heading function, it uses the `headerIds` option added in version `0.4.0`.

It also pass down the `options` parameter to marked to add the ability to set the `headerIds` or any options to marked.