### PR TITLE
svelte "support" lol

### DIFF
--- a/lib/helpers/raw.js
+++ b/lib/helpers/raw.js
@@ -13,7 +13,7 @@ var TerraformError = exports.TerraformError = require("../error").TerraformError
  */
 
 var processors = exports.processors = {
-  "html": ["jade", "ejs", "md"],
+  "html": ["jade", "ejs", "md", "svelte"],
   "css" : ["styl", "less", "scss", "sass"],
   "js"  : ["jsx", "cjs", "coffee"]
 }

--- a/lib/template/processors/svelte.js
+++ b/lib/template/processors/svelte.js
@@ -1,0 +1,50 @@
+var fs = require("fs");
+var path = require("path");
+var { compile } = require("svelte/compiler");
+var TerraformError = require("../../error").TerraformError
+
+module.exports = function(fileContents, options){
+
+  return {
+    compile: function(){
+      var result = compile(fileContents.toString(), {
+        generate: 'ssr',
+        format: 'cjs'
+      });
+
+      console.log(result);
+
+      var ohNoThinkOfTheChildren = path.join(__dirname, `wat-am-i-doing-help-${Date.now()}.js`)
+
+      fs.writeFileSync(ohNoThinkOfTheChildren, result.js.code);
+
+      var Component = require(ohNoThinkOfTheChildren).default;
+
+      fs.unlinkSync(ohNoThinkOfTheChildren);
+
+      return function(args) {
+        console.log(args);
+        var rendered = Component.render(args);
+        console.log(rendered);
+        return `${rendered.html}<style>${rendered.css.code}</style>`;
+      };
+    },
+
+    parseError: function(error){
+      console.error(error);
+      var arr = error.message.split("\n")
+      var path_arr = arr[0].split(":")
+
+      error.lineno    = parseInt(error.lineno || path_arr[path_arr.length -1] || -1)
+      error.message   = arr[arr.length - 1]
+      error.name      = error.name
+      error.source    = "Svelte"
+      error.dest      = "HTML"
+      error.filename  = error.path || options.filename
+      error.stack     = fileContents.toString()
+
+      return new TerraformError(error)
+    }
+  }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "terraform",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.20.1",
+      "name": "terraform",
+      "version": "1.20.2",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6",
@@ -14,6 +15,7 @@
         "marked": "^4.0.10",
         "react": "^17.0.2",
         "sass": "^1.29.0",
+        "svelte": "^3.46.2",
         "through": "2.3.8"
       },
       "devDependencies": {
@@ -1343,6 +1345,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/svelte": {
+      "version": "3.46.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+      "integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2547,6 +2557,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svelte": {
+      "version": "3.46.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+      "integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "marked": "^4.0.10",
     "react": "^17.0.2",
     "sass": "^1.29.0",
+    "svelte": "^3.46.2",
     "through": "2.3.8"
   },
   "devDependencies": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,8 +9,8 @@ describe("helpers", function(){
     it('should return all possible file names for html ordered by priority.', function(done){
       var list = polymer.helpers.buildPriorityList('index.html')
       list.should.be.an.instanceOf(Array)
-      list.should.have.lengthOf(6)
-      var plist = "index.jade, index.ejs, index.md, index.html.jade, index.html.ejs, index.html.md".split(', ')
+      list.should.have.lengthOf(8)
+      var plist = "index.jade, index.ejs, index.md, index.svelte, index.html.jade, index.html.ejs, index.html.md, index.html.svelte".split(', ')
       list.should.eql(plist)
       done()
     })
@@ -43,27 +43,28 @@ describe("helpers", function(){
     it('should build priority list assuming template file when unknown.', function(done){
       var list = polymer.helpers.buildPriorityList('feed.xml')
       list.should.be.an.instanceOf(Array)
-      list.should.have.lengthOf(3)
-      list.should.eql('feed.xml.jade, feed.xml.ejs, feed.xml.md'. split(', '))
+      list.should.have.lengthOf(4)
+      list.should.eql('feed.xml.jade, feed.xml.ejs, feed.xml.md, feed.xml.svelte'. split(', '))
       done()
     })
 
     it('should look for templates on json files.', function(done){
       var list = polymer.helpers.buildPriorityList('profile.json')
       list.should.be.an.instanceOf(Array)
-      list.should.have.lengthOf(3)
+      list.should.have.lengthOf(4)
       list.should.include('profile.json.jade')
       list.should.include('profile.json.ejs')
       list.should.include('profile.json.md')
-      list.should.eql('profile.json.jade, profile.json.ejs, profile.json.md'. split(', '))
+      list.should.include('profile.json.svelte')
+      list.should.eql('profile.json.jade, profile.json.ejs, profile.json.md, profile.json.svelte'. split(', '))
       done()
     })
 
     it('should look for templates when no ext present.', function(done){
       var list = polymer.helpers.buildPriorityList('appcache')
       list.should.be.an.instanceOf(Array)
-      list.should.have.lengthOf(3)
-      list.should.eql('appcache.jade, appcache.ejs, appcache.md'.split(', '))
+      list.should.have.lengthOf(4)
+      list.should.eql('appcache.jade, appcache.ejs, appcache.md, appcache.svelte'.split(', '))
       done()
     })
 


### PR DESCRIPTION
Listen, this "works" but I just wanted to get _something_ working.

The following `index.svelte` works as expected:

```svelte
<script>
  export let current;
</script>

<h1>Hi {current.source}</h1>

<style>
  h1 {
    color: red;
  }
</style>
```

The amazing thing about having Svelte support in Harp (besides using Svelte syntax, duh) would be scoped CSS. None of the other template languages give you that. The generated HTML for the above is currently this

```html
<h1 class="svelte-1tb9iu1">Hi index</h1><style>h1.svelte-1tb9iu1{color:red}</style>
```

Two open questions, if we solve those we got ourselves the first Svelte iteration:

1. What do we do about that temporary file I'm hacking around? The `compile` call returns (among other things) the JavaScript code (a string) for a CJS module. So there must be a better way. There is [`svelte/register`](https://svelte.dev/docs#run-time-svelte-register), need to check how that works internally because it gives us the compiled component straight away.
2. CSS! Every component returns its scoped CSS, which I'm currently injecting into a `<style>` tag. It "works" but it would probably nicer to write out a CSS file?

I also noticed your JSX "implementation" is copy and paste of EJS without editing it, I assume you didn't commit your tests?

I tried working with SvelteKit and the adapter-static but I'm just not happy with it. I don't like the UX of a client side router, I just want static HTML pages and I'm good. I'd even accept the inline `<style>` for now.